### PR TITLE
Prevent anonymous file resizing via seals if possible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,9 @@ impl<T> Drop for MmapRegion<T> {
 ///
 /// The data is owned, but the element of type `T` will *not* be dropped when the `Shared<T>` is
 /// dropped. Note that an element that has a meaningful `Drop` is likely not `ProcSync` anyway.
+///
+/// Note that the anonymous file associated with this memory mapping is sealed and
+/// cannot be resized, otherwise `SIGBUS` could be hit if the file were truncated.
 pub struct Shared<T> {
     fd: RawFd,
     region: MmapRegion<T>,


### PR DESCRIPTION
This prevents anonymous file truncating which could lead to SIGBUS for filesystems that support sealing, as mentionned [here](https://github.com/standard-ai/caring/pull/5#issuecomment-652865511).

I think that this is a sane default because I can't really think of a reason why the user would want to resize the shared memory since he would have to munmap first and currently he can't get back ownership of the `MmapRegion` anyway.

Note that im ignoring the errors returned by `fcntl` because I've determined that most of them will never occur, and the only one that can occur is worth ignoring. Specifically, according to the [fcntl manpage](https://man7.org/linux/man-pages/man2/fcntl.2.html#ERRORS), these are the possible errors related to seals:

> EBUSY [...] if flag includes F_SEAL_WRITE, [...]

Can't happen since we don't currently use that seal and it wouldn't make sense to add support for it in this context.

> EINVAL [...] if flags are invalid

I've determined that the flags are valid.

> EPERM  [...] file already includes F_SEAL_SEAL.

This won't happen because of the `allow_sealing` option.

> EINVAL [...] if the filesystem containing the inode referred to by fd does not support sealing.

This one could occur, in which case sealing fails. Realistically, unless the user absolutely needs a guarantee against resizing, I can't see a justification for error'ing out.